### PR TITLE
fix: LUREST_DISPATCH_TOKEN を secrets から inputs に変更

### DIFF
--- a/.github/workflows/dispatch-test.yml
+++ b/.github/workflows/dispatch-test.yml
@@ -13,10 +13,10 @@ on:
         required: false
         default: "Dispatched via workflow-gateway"
         type: string
-    secrets:
       LUREST_DISPATCH_TOKEN:
         description: "fine-grained PAT(private-workflows に対して Actions: write が必要)"
         required: true
+        type: string
 
 jobs:
   dispatch:
@@ -58,10 +58,13 @@ jobs:
             test-b) echo "workflow_file=test-b.yml" >> "$GITHUB_OUTPUT" ;;
           esac
 
+      - name: Mask sensitive token
+        run: echo "::add-mask::${{ inputs.LUREST_DISPATCH_TOKEN }}"
+
       - name: Dispatch private workflow
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.LUREST_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ inputs.LUREST_DISPATCH_TOKEN }}
           TARGET_REPO: lurest-inc/private-workflows
           WORKFLOW_FILE: ${{ steps.resolve.outputs.workflow_file }}
           TARGET_REF: main


### PR DESCRIPTION
Closes #5

## 📝 変更内容

`dispatch-test.yml` の `LUREST_DISPATCH_TOKEN` を `secrets:` から `inputs:` に変更しました。

### 主な変更点

1. **定義の変更** 🔧
   - `workflow_call` の `secrets:` セクションから `LUREST_DISPATCH_TOKEN` を削除
   - `inputs:` セクションに移動し、`type: string` を追加

2. **参照の更新** 🔄
   - `${{ secrets.LUREST_DISPATCH_TOKEN }}` → `${{ inputs.LUREST_DISPATCH_TOKEN }}`

3. **セキュリティ対応** 🔐
   - トークンをマスクする新しいステップを追加
   - ログに平文で露出しないよう `add-mask` を使用

## 🎯 目的

`gh workflow run --field` でトークンを渡せるようにするための対応です。
`--field` フラグは `inputs` のみ対応しており、`secrets` には対応していないため、この変更が必要でした。

## ✅ 動作確認

- [x] `LUREST_DISPATCH_TOKEN` が `inputs` として定義されている
- [x] `type: string` と `required: true` が設定されている
- [x] 参照が `inputs.LUREST_DISPATCH_TOKEN` に更新されている
- [x] `add-mask` によるマスキングが実装されている

## 📚 参考

- [gh workflow run のドキュメント](https://cli.github.com/manual/gh_workflow_run)