### PR TITLE
chore: private-workflowsの参照バージョンをv0.0.4に更新し dispatch_token を追加する

### DIFF
--- a/.github/workflows/call-test.yml
+++ b/.github/workflows/call-test.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   call-test-b:
     if: ${{ inputs.target == 'test-b' }}
-    uses: lurest-inc/private-workflows/.github/workflows/test-b.yml@v0.0.3
+    uses: lurest-inc/private-workflows/.github/workflows/test-b.yml@v0.0.4
     with:
       caller_repo: ${{ github.repository }}
       message: ${{ inputs.message }}

--- a/.github/workflows/claude-gateway.yml
+++ b/.github/workflows/claude-gateway.yml
@@ -40,7 +40,7 @@ jobs:
 
   gateway:
     needs: gatewayGuard
-    uses: lurest-inc/private-workflows/.github/workflows/cc-gateway-receiver.yml@v0.0.3
+    uses: lurest-inc/private-workflows/.github/workflows/cc-gateway-receiver.yml@v0.0.4
     with:
       event_name: ${{ github.event_name }}
       action: ${{ github.event.action || '' }}
@@ -53,3 +53,4 @@ jobs:
       sender_login: ${{ github.event.sender.login || '' }}
     secrets:
       owner_token: ${{ secrets.owner_token }}
+      dispatch_token: ${{ secrets.LUREST_DISPATCH_TOKEN }}

--- a/.github/workflows/dispatch-test.yml
+++ b/.github/workflows/dispatch-test.yml
@@ -73,7 +73,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARGET_REPO: lurest-inc/private-workflows
           WORKFLOW_FILE: ${{ steps.resolve.outputs.workflow_file }}
-          TARGET_REF: v0.0.3
+          TARGET_REF: v0.0.4
           CALLER_REPO: ${{ github.repository }}
           MESSAGE: ${{ inputs.message }}
         run: |


### PR DESCRIPTION
## Summary

- 全ワークフローの private-workflows 参照バージョンを `v0.0.3` → `v0.0.4` に更新
- `claude-gateway.yml` に `dispatch_token` シークレット (`LUREST_DISPATCH_TOKEN`) を追加

## Test plan

- [ ] `dispatch-test.yml` が v0.0.4 を参照して正常に動作することを確認
- [ ] `claude-gateway.yml` が `dispatch_token` を正しく受け渡すことを確認

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)