### PR TITLE
docs: セットアップ手順を改善しOWNER_TOKENを追加する

### DIFF
--- a/.github/workflows/claude-gateway.yml
+++ b/.github/workflows/claude-gateway.yml
@@ -28,12 +28,12 @@ jobs:
 
           [ "$HTTP_STATUS" = "200" ] || (echo "::error::Token verification failed" && exit 1)
         env:
-          PRIVATE_WORKFLOWS_REF: v0.0.5
+          PRIVATE_WORKFLOWS_REF: v0.0.6
           TOKEN: ${{ secrets.LUREST_DISPATCH_TOKEN }}
 
   gateway:
     needs: gatewayGuard
-    uses: lurest-inc/private-workflows/.github/workflows/cc-gateway-receiver.yml@v0.0.5
+    uses: lurest-inc/private-workflows/.github/workflows/cc-gateway-receiver.yml@v0.0.6
     with:
       event_name: ${{ github.event_name }}
       action: ${{ github.event.action || '' }}

--- a/README.md
+++ b/README.md
@@ -11,37 +11,50 @@ Lurest の private workflows を `workflow_dispatch` で起動するための **
 |------------|------------|------------|
 | Claude Gateway | [docs/claude-gateway.md](docs/claude-gateway.md) | [/claude-gateway](https://lurest-inc.github.io/workflow-gateway/claude-gateway) |
 
-## 共通セットアップ
+## セットアップ手順
 
-各ワークフローを利用するには、リポジトリの **Settings > Secrets and variables > Actions** で以下の Secret を登録してください。
+このワークフローを利用するには、以下の手順が必要です。
 
-| Secret名 | 説明 |
-|---------|------|
-| `LUREST_DISPATCH_TOKEN` | `lurest-inc/private-workflows` へのアクセス権を持つ PAT（Personal Access Token）。リポジトリ管理者から取得してください。 |
+### 利用者（リポジトリのオーナー）が行う手順
 
-> **注意**: `LUREST_DISPATCH_TOKEN` が無効またはアクセス権がない場合、ワークフローの実行は `gatewayGuard` ジョブで停止されます。
-
-## 依頼について
-
-このワークフローを利用するには、事前に以下の手順を踏む必要があります。
-
-### 1. リポジトリに @mabubu0203 を招待する
+#### 1. リポジトリに @mabubu0203 を招待する
 
 リポジトリの **Settings > Collaborators and teams** から @mabubu0203 を招待してください。
 
-Secret の登録には **Admin** ロールが必要です。以下を参考にロールを設定してください。
+##### ロール要件
 
-| ロール | Secret の登録（Settings UI） |
-|-------|:---:|
-| Read / Triage / Write / Maintain | ✗ |
-| **Admin** | ✅ |
+管理者（@mabubu0203）にはリポジトリへの以下の権限が必要です。
 
-> **注意**: @mabubu0203 を招待する際は、ロールを **Admin** に設定してください。
+| 作業 | 必要なロール |
+|------|-----------|
+| ブランチ作成、コミット、PR作成 | **Write** 以上 |
+| Secret の登録（Settings UI） | **Admin** |
 
-### 2. @mabubu0203 に PAT 発行を依頼する
+> **推奨**: 管理者には **Admin** ロール を付与することをお勧めします。その方が作業がスムーズです。
 
-Issue またはメッセージで @mabubu0203 に `LUREST_DISPATCH_TOKEN` の発行を依頼してください。
-@mabubu0203 が PAT の発行から Secret の登録まで行います。
+#### 2. @mabubu0203 に PAT 発行を依頼する
 
-> @mabubu0203 側の作業内容は [docs/setup-for-admin.md](docs/setup-for-admin.md) を参照してください。
+Issue またはメッセージで @mabubu0203 に以下の内容を依頼してください。
+
+- 利用者のリポジトリへのアクセス権を持つ PAT（`OWNER_TOKEN` として登録）
+- `lurest-inc/private-workflows` へのアクセス権を持つ PAT（`LUREST_DISPATCH_TOKEN` として登録）
+
+### @mabubu0203（管理者）が行う手順
+
+@mabubu0203 は以下のドキュメントに従って作業を進めてください。
+
+> [docs/setup-for-admin.md](docs/setup-for-admin.md) を参照してください。
+
+主な作業内容：
+1. 招待を承認する
+2. GitHub Actions を有効化する
+3. 2つの PAT を発行する
+   - 利用者のリポジトリ用
+   - `lurest-inc/private-workflows` 用
+4. 利用者のリポジトリに Secret を登録する
+   - `OWNER_TOKEN`
+   - `LUREST_DISPATCH_TOKEN`
+5. 利用者のリポジトリに Workflow ファイルと Claude Code コマンド設定を追加する
+   - `.github/workflows/setup-claude.yml`
+   - `.claude/commands/`（ブランチを切ってコミット）
 

--- a/docs/claude-gateway.md
+++ b/docs/claude-gateway.md
@@ -13,11 +13,9 @@
 
 | Secret名 | 必須 | 説明 |
 |---------|:----:|------|
-| `owner_token` | ✅ | GitHub Actions が自動提供するトークン。明示的な設定は不要ですが、呼び出し元で渡す必要があります。 |
-| `LUREST_DISPATCH_TOKEN` | 任意* | `lurest-inc/private-workflows` へのアクセス権を持つ PAT。リポジトリ管理者から取得してください。 |
+| `OWNER_TOKEN` | ✅ | 利用者のリポジトリへのアクセス権を持つ PAT。`lurest-inc/private-workflows` でのクロスリポジトリのチェックアウトと ClaudeCodeAction の実行に必要です。 |
+| `LUREST_DISPATCH_TOKEN` | ✅  | `lurest-inc/private-workflows` へのアクセス権を持つ PAT。gateway が private-workflows のワークフローを呼び出すために必要です。 |
 
-> * ワークフロー定義上は任意ですが、未設定の場合でも `gatewayGuard` ジョブで失敗するため、通常の利用時は設定することを強く推奨します。
-> **注意**: `LUREST_DISPATCH_TOKEN` が未設定、無効、またはアクセス権がない場合、`gatewayGuard` ジョブでワークフローが停止します。
 ## ジョブ構成
 
 ```
@@ -36,9 +34,9 @@ name: Setup Claude
 
 on:
   issues:
-    types: [opened, edited, labeled, unlabeled]
+    types: [opened, labeled]
   pull_request:
-    types: [opened, edited, labeled, unlabeled, synchronize]
+    types: [opened, labeled]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -46,9 +44,9 @@ on:
 
 jobs:
   claude:
-    uses: lurest-inc/workflow-gateway/.github/workflows/claude-gateway.yml@v0.0.3
+    uses: lurest-inc/workflow-gateway/.github/workflows/claude-gateway.yml@v0.0.6
     secrets:
-      owner_token: ${{ secrets.GITHUB_TOKEN }}
+      owner_token: ${{ secrets.OWNER_TOKEN }}
       LUREST_DISPATCH_TOKEN: ${{ secrets.LUREST_DISPATCH_TOKEN }}
 ```
 

--- a/docs/setup-for-admin.md
+++ b/docs/setup-for-admin.md
@@ -6,7 +6,49 @@
 
 利用者のリポジトリから招待が届いたら、GitHub の通知から承認してください。
 
-## 2. PAT（Personal Access Token）を発行する
+## 2. GitHub Actions を有効化する
+
+利用者のリポジトリで GitHub Actions が有効になっているか確認し、必要に応じて有効化してください。
+
+1. リポジトリの **Settings > Actions > General** を開く
+2. **Actions permissions** セクションで以下を確認/設定する
+
+| 設定項目 | 設定値 |
+|---------|--------|
+| Actions | Allow all actions and reusable workflows |
+
+3. **Workflow permissions** セクションで以下を設定する
+
+| 設定項目 | 設定値 |
+|---------|--------|
+| Default permissions | Read and write permissions |
+| Allow GitHub Actions to create and approve pull requests | ✅ 有効化 |
+
+> **注意**: PR作成やコミットなどの自動化を行うため、これらの権限が必要です。
+
+## 3. PAT（Personal Access Token）を発行する
+
+### 利用者のリポジトリ
+
+`利用者のリポジトリ` へのアクセス権を持つ fine-grained PAT を発行します。
+
+1. GitHub の **Settings > Developer settings > Personal access tokens > Fine-grained tokens** を開く
+2. **Generate new token** をクリック
+3. 以下の設定で発行する
+
+| 項目 | 設定値 |
+|------|--------|
+| Resource owner | （リポジトリのオーナー） |
+| Expiration | `30 days`（30日ごとに再発行が必要） |
+| Repository access | `Only select repositories` → 利用者のリポジトリを選択 |
+| Permissions > Actions | `Read and write` |
+| Permissions > Contents | `Read and write` |
+| Permissions > Pull requests | `Read and write` |
+| Permissions > Issues | `Read and write` |
+
+> **注意**: PAT の有効期限は **30日間**です。期限切れ前に再発行して利用者に共有してください。
+
+### lurest-inc/private-workflows
 
 `lurest-inc/private-workflows` へのアクセス権を持つ fine-grained PAT を発行します。
 
@@ -24,12 +66,47 @@
 
 > **注意**: PAT の有効期限は **30日間**です。期限切れ前に再発行して利用者に共有してください。
 
-4. 発行された PAT を利用者のリポジトリへ登録する
-
-## 3. 利用者のリポジトリに Secret を登録する
+## 4. 利用者のリポジトリに Secret を登録する
 
 招待を承認したリポジトリの **Settings > Secrets and variables > Actions** を開き、以下の Secret を登録してください。
 
 | Secret名 | 値 |
 |---------|---|
-| `LUREST_DISPATCH_TOKEN` | 手順2で発行した PAT |
+| `OWNER_TOKEN` | `利用者のリポジトリ` で発行した PAT |
+| `LUREST_DISPATCH_TOKEN` | `lurest-inc/private-workflows` で発行した PAT |
+
+## 5. 利用者のリポジトリに Workflow ファイルを追加する
+
+Claude Gateway のワークフローファイルを利用者のリポジトリに追加します。
+
+### 1. ブランチを作成する
+
+```bash
+git checkout -b setup/claude-gateway
+```
+
+### 2. ファイルを作成する
+
+#### 2.1 ワークフローファイルを作成する
+
+`.github/workflows/` ディレクトリを作成し、以下の内容で `setup-claude.yml` を新規作成してください。
+
+[docs/claude-gateway.md](../docs/claude-gateway.md) の「呼び出しサンプル」を参考にして下さい。
+
+#### 2.2 Claude Code コマンド設定を追加する
+
+`.claude/commands/` ディレクトリを作成し、private-workflows で利用するファイルを追加してください。
+
+### 3. コミットして Push する
+
+```bash
+git add .github/workflows/setup-claude.yml .claude/commands/
+git commit -m "chore: add Claude Gateway workflow and commands"
+git push origin setup/claude-gateway
+```
+
+### 4. Pull Request を作成する
+
+GitHub で PR を作成し、レビュー後に main ブランチにマージしてください。
+
+> **注意**: ワークフローが正しく動作することを確認してから、利用者に通知してください。


### PR DESCRIPTION
## Summary

- README.mdのセットアップ手順を「利用者が行う手順」「管理者が行う手順」に役割別で整理
- `docs/setup-for-admin.md` にGitHub Actions有効化手順（手順2）と利用者リポジトリ用PAT発行手順を追加
- `docs/claude-gateway.md` のSecret名を `owner_token` → `OWNER_TOKEN` に変更し、ワークフロートリガーの event types を `opened, labeled` に絞り込み
- `claude-gateway.yml` の private-workflows バージョン参照を `v0.0.5` → `v0.0.6` に更新

## Test plan

- [ ] README.mdのセットアップ手順が利用者/管理者の観点から読んで分かりやすいか確認
- [ ] docs/setup-for-admin.mdの手順が上から順に実施できるか確認
- [ ] docs/claude-gateway.mdの呼び出しサンプルがOWNER_TOKENを使用しているか確認

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)