### PR TITLE
chore: ワークフロー参照をv0.0.20に更新

### DIFF
--- a/.github/workflows/claude-gateway.yml
+++ b/.github/workflows/claude-gateway.yml
@@ -28,12 +28,12 @@ jobs:
 
           [ "$HTTP_STATUS" = "200" ] || (echo "::error::Token verification failed" && exit 1)
         env:
-          PRIVATE_WORKFLOWS_REF: v0.0.19
+          PRIVATE_WORKFLOWS_REF: v0.0.20
           TOKEN: ${{ secrets.LUREST_DISPATCH_TOKEN }}
 
   gateway:
     needs: gatewayGuard
-    uses: lurest-inc/private-workflows/.github/workflows/cc-gateway-receiver.yml@v0.0.19
+    uses: lurest-inc/private-workflows/.github/workflows/cc-gateway-receiver.yml@v0.0.20
     with:
       event_name: ${{ github.event_name }}
       action: ${{ github.event.action || '' }}


### PR DESCRIPTION
Closes #80

## 概要

private-workflows の参照バージョンを v0.0.19 から v0.0.20 に更新します。

## 変更内容

- chore: ワークフロー参照をv0.0.20に更新 #80

## 動作確認

- [ ] ローカルで動作確認済み
- [ ] Biome チェック通過
- [ ] actionlint チェック通過

## 影響範囲

- .github/workflows/claude-gateway.yml